### PR TITLE
Implement fix option for block header comments

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -41,20 +41,35 @@ module.exports = function(context) {
                 leadingComments = context.getComments(node).leading;
             }
 
+            function fixerCallback(fixer) {
+                return fixer.insertTextBefore(node, text + "\n");
+            }
+
             if (!leadingComments.length) {
-                context.report(node, "missing header");
+                context.report({
+                    node: node,
+                    message: "missing header",
+                    fix: fixerCallback
+                });
             } else if (leadingComments[0].type.toLowerCase() !== commentType) {
                 context.report(node, "header should be a " + commentType + " comment");
             } else {
                 if (commentType === "line") {
                     for (var i = 0; i < headerLines.length; i++) {
                         if (leadingComments[i].value !== headerLines[i]) {
-                            context.report(node, "incorrect header");
+                            context.report({
+                                node: node,
+                                message: "incorrect header"
+                            });
                             return;
                         }
                     }
                 } else if (leadingComments[0].value !== header) {
-                    context.report(node, "incorrect header");
+                    context.report({
+                        node: node,
+                        message: "incorrect header",
+                        fix: fixerCallback
+                    });
                 }
             }
         }


### PR DESCRIPTION
See http://eslint.org/blog/2015/09/eslint-v1.5.0-released/#autofixing-of-more-rules and http://eslint.org/docs/developer-guide/working-with-rules#applying-fixes.

Only adds the specified block header if missing or incorrect content. Incorrect comment type (line vs. block) and incorrect line-by-line content errors not handled yet.
