### PR TITLE
fix length mismatch bug

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -47,7 +47,7 @@ module.exports = function(context) {
                 context.report(node, "header should be a " + commentType + " comment");
             } else {
                 if (commentType === "line") {
-                    if (leadingComments.length !== headerLines.length) {
+                    if (leadingComments.length < headerLines.length) {
                         context.report(node, "incorrect header");
                         return;
                     }

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -47,6 +47,10 @@ module.exports = function(context) {
                 context.report(node, "header should be a " + commentType + " comment");
             } else {
                 if (commentType === "line") {
+                    if (leadingComments.length !== headerLines.length) {
+                        context.report(node, "incorrect header");
+                        return;
+                    }
                     for (var i = 0; i < headerLines.length; i++) {
                         if (leadingComments[i].value !== headerLines[i]) {
                             context.report(node, "incorrect header");

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -46,6 +46,10 @@ ruleTester.run("header", rule, {
         {
             code: "// Copyright 2015\n// My Company\nconsole.log(1)",
             options: ["tests/support/line.js"]
+        },
+        {
+            code: "//Copyright 2015\n//My Company\n/* DOCS */",
+            options: ["line", "Copyright 2015\nMy Company"]
         }
     ],
     invalid: [

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -83,6 +83,13 @@ ruleTester.run("header", rule, {
             errors: [
                 {message: "incorrect header"}
             ]
+        },
+        {
+            code: "//Copyright 2015",
+            options: ["line", "Copyright 2015\nMy Company"],
+            errors: [
+                {message: "incorrect header"}
+            ]
         }
     ]
 });


### PR DESCRIPTION
Additional test cases fail with the following error without the code changes included.

```
  1) header //Copyright 2015:
     TypeError: Cannot read property 'value' of undefined
      at EventEmitter.Program (lib/rules/header.js:54:47)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/util/node-event-generator.js:42:22)
      at CommentEventGenerator.enterNode (node_modules/eslint/lib/util/comment-event-generator.js:98:23)
      at Controller.controller.traverse.enter (node_modules/eslint/lib/eslint.js:767:36)
      at Controller.__execute (node_modules/eslint/node_modules/estraverse/estraverse.js:397:31)
      at Controller.traverse (node_modules/eslint/node_modules/estraverse/estraverse.js:501:28)
      at EventEmitter.module.exports.api.verify (node_modules/eslint/lib/eslint.js:764:24)
      at runRuleForItem (node_modules/eslint/lib/testers/rule-tester.js:303:38)
      at testInvalidTemplate (node_modules/eslint/lib/testers/rule-tester.js:343:26)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:411:21)
```
