### PR TITLE
Allow RegExp patterns in addition to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ In the 2 argument form the first must be either `"block"` or `"line"` to indicia
 }
 ```
 
+Instead of a string to be checked for exact matching you can also supply a regular expression (beware that you have to quote backslashes):
+
+```json
+{
+    "plugins": [
+        "header"
+    ],
+    "rules": {
+        "header/header": [2, "block", {"pattern": "^ Copyright \\d{4}\\n My Company$"}]
+    }
+}
+```
+
 ## Examples
 
 The following examples are all valid.
@@ -63,6 +76,14 @@ console.log(1);
 
 ```js
 //Copyright 2015
+//My Company
+console.log(1)
+```
+
+`"line", [{pattern: "^Copyright \\d{4}$"}, {pattern: "^My Company$"}]]`:
+
+```js
+//Copyright 2017
 //My Company
 console.log(1)
 ```

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -19,6 +19,8 @@ module.exports = function(context) {
     if (commentType === "line") {
         if (Array.isArray(options[1])) {
             headerLines = options[1];
+        } else if (typeof options[1] === "object" && options[1].hasOwnProperty('pattern')) {
+            headerLines = [options[1]];
         } else {
             // TODO split on \r as well
             headerLines = options[1].split("\n");
@@ -46,19 +48,29 @@ module.exports = function(context) {
             } else if (leadingComments[0].type.toLowerCase() !== commentType) {
                 context.report(node, "header should be a " + commentType + " comment");
             } else {
+                var match;
                 if (commentType === "line") {
                     if (leadingComments.length < headerLines.length) {
                         context.report(node, "incorrect header");
                         return;
                     }
                     for (var i = 0; i < headerLines.length; i++) {
-                        if (leadingComments[i].value !== headerLines[i]) {
+                        match = (typeof headerLines[i] === 'object' &&
+                                 headerLines[i].hasOwnProperty('pattern')) ?
+                                leadingComments[i].value.match(new RegExp(headerLines[i].pattern)) :
+                                leadingComments[i].value === headerLines[i];
+                        if (!match) {
                             context.report(node, "incorrect header");
                             return;
                         }
                     }
-                } else if (leadingComments[0].value !== header) {
-                    context.report(node, "incorrect header");
+                } else {
+                    match = (typeof header === 'object' && header.hasOwnProperty('pattern')) ?
+                            leadingComments[0].value.match(new RegExp(header.pattern)) :
+                            leadingComments[0].value === header;
+                    if (!match) {
+                        context.report(node, "incorrect header");
+                    }
                 }
             }
         }

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -50,7 +50,19 @@ ruleTester.run("header", rule, {
         {
             code: "//Copyright 2015\n//My Company\n/* DOCS */",
             options: ["line", "Copyright 2015\nMy Company"]
-        }
+        },
+        {
+            code: "// Copyright 2017",
+            options: ["line", {pattern: "^ Copyright \\d+$"}]
+        },
+        {
+            code: "// Copyright 2017\n// Author: abc@example.com",
+            options: ["line", [{pattern: "^ Copyright \\d+$"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}]]
+        },
+        {
+            code: "/* Copyright 2017\n Author: abc@example.com */",
+            options: ["block", {pattern: "^ Copyright \\d{4}\\n Author: \\w+@\\w+\\.\\w+ $"}]
+        },
     ],
     invalid: [
         {
@@ -94,6 +106,27 @@ ruleTester.run("header", rule, {
             errors: [
                 {message: "incorrect header"}
             ]
-        }
+        },
+        {
+            code: "// Copyright 2017 trailing",
+            options: ["line", {pattern: "^ Copyright \\d+$"}],
+            errors: [
+                {message: "incorrect header"}
+            ]
+        },
+        {
+            code: "// Copyright 2017\n// Author: ab-c@example.com",
+            options: ["line", [{pattern: "Copyright \\d+"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}]],
+            errors: [
+                {message: "incorrect header"}
+            ]
+        },
+        {
+            code: "/* Copyright 2017-01-02\n Author: abc@example.com */",
+            options: ["block", {pattern: "^ Copyright \\d+\\n Author: \\w+@\\w+\\.\\w+ $"}],
+            errors: [
+                {message: "incorrect header"}
+            ]
+        },
     ]
 });


### PR DESCRIPTION
Instead of just allowing to specify exact strings to be matched this
patch allows the user to specify RegExp patterns.

Fixes Stuk/eslint-plugin-header#2