### PR TITLE
user defined error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ Instead of a string to be checked for exact matching you can also supply a regul
 }
 ```
 
+### 3 arguments
+In the 3 argument, the last is optional string error message, defined by user.
+```json
+{
+    "plugins": [
+        "header"
+    ],
+    "rules": {
+        "header/header": [2, "line", {"pattern": "^ Copyright \\d{4}\\n My Company$"}, "Copyright information error. Please add below line to your file.\n\tCopyright (c) 2017 ABC Inc. All rights reserved""]
+    }
+}
+```
+
 ## Examples
 
 The following examples are all valid.

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -15,8 +15,12 @@ function match(actual, expected) {
     }
 }
 
+
 module.exports = function(context) {
     var options = context.options;
+
+    // get error message form user config
+    var errorMessage = options[2] && typeof options[2] === 'string' ? options[2] : 'incorrect header';
 
     // If just one option then read comment from file
     if (options.length === 1) {
@@ -33,9 +37,11 @@ module.exports = function(context) {
             headerLines = options[1].map(function(line) {
                 return isPattern(line) ? new RegExp(line.pattern) : line;
             });
-        } else if (isPattern(options[1])) {
+        }
+        else if (isPattern(options[1])) {
             headerLines = [new RegExp(options[1].pattern)];
-        } else {
+        } 
+        else {
             // TODO split on \r as well
             headerLines = options[1].split("\n");
         }
@@ -59,24 +65,24 @@ module.exports = function(context) {
             }
 
             if (!leadingComments.length) {
-                context.report(node, "missing header");
+                context.report(node, errorMessage);
             } else if (leadingComments[0].type.toLowerCase() !== commentType) {
                 context.report(node, "header should be a " + commentType + " comment");
             } else {
                 if (commentType === "line") {
                     if (leadingComments.length < headerLines.length) {
-                        context.report(node, "incorrect header");
+                        context.report(node, errorMessage);
                         return;
                     }
                     for (var i = 0; i < headerLines.length; i++) {
                         if (!match(leadingComments[i].value, headerLines[i])) {
-                            context.report(node, "incorrect header");
+                            context.report(node, errorMessage);
                             return;
                         }
                     }
                 } else {
                     if (!match(leadingComments[0].value, header)) {
-                        context.report(node, "incorrect header");
+                        context.report(node, errorMessage);
                     }
                 }
             }

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -127,6 +127,13 @@ ruleTester.run("header", rule, {
             errors: [
                 {message: "incorrect header"}
             ]
+        },
+        {
+            code: "/* Copyright 20\n Author: abc@example.com */",
+            options: ["block", {pattern: "^\\s*Copyright \\(c\\) \\d{4} ABC Inc. All rights reserved.\\s*$"}, "Copyright information error. Please add below line to your file.\n\tCopyright (c) " + new Date().getFullYear() + " ABC Inc. All rights reserved"],
+            errors: [
+                {message: "Copyright information error. Please add below line to your file.\n\tCopyright (c) " + new Date().getFullYear() + " ABC Inc. All rights reserved"}
+            ]
         }
     ]
 });


### PR DESCRIPTION
Hi Stuk, we are using this header checker plugin and for some reason we need to define the error message by ourselves.
So I expand another argument to store it.
