### PR TITLE
Ignore shebangs above header comments to support ESLint 4+

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -51,12 +51,17 @@ module.exports = function(context) {
 
     return {
         Program: function(node) {
-            var leadingComments;
-            if (node.body.length) {
-                leadingComments = context.getComments(node.body[0]).leading;
-            } else {
-                leadingComments = context.getComments(node).leading;
+            function excludeShebangs(comments) {
+                return comments.filter(function(comment) { return comment.type !== "Shebang"; });
             }
+
+            function getLeadingComments() {
+                return node.body.length ?
+                    context.getComments(node.body[0]).leading :
+                    context.getComments(node).leading;
+            }
+
+            var leadingComments = excludeShebangs(getLeadingComments());
 
             if (!leadingComments.length) {
                 context.report(node, "missing header");

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -15,6 +15,16 @@ function match(actual, expected) {
     }
 }
 
+function excludeShebangs(comments) {
+    return comments.filter(function(comment) { return comment.type !== "Shebang"; });
+}
+
+function getLeadingComments(context, node) {
+    return node.body.length ?
+        context.getComments(node.body[0]).leading :
+        context.getComments(node).leading;
+}
+
 module.exports = function(context) {
     var options = context.options;
 
@@ -51,17 +61,7 @@ module.exports = function(context) {
 
     return {
         Program: function(node) {
-            function excludeShebangs(comments) {
-                return comments.filter(function(comment) { return comment.type !== "Shebang"; });
-            }
-
-            function getLeadingComments() {
-                return node.body.length ?
-                    context.getComments(node.body[0]).leading :
-                    context.getComments(node).leading;
-            }
-
-            var leadingComments = excludeShebangs(getLeadingComments());
+            var leadingComments = excludeShebangs(getLeadingComments(context, node));
 
             if (!leadingComments.length) {
                 context.report(node, "missing header");

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -62,6 +62,14 @@ ruleTester.run("header", rule, {
         {
             code: "/* Copyright 2017\n Author: abc@example.com */",
             options: ["block", {pattern: "^ Copyright \\d{4}\\n Author: \\w+@\\w+\\.\\w+ $"}]
+        },
+        {
+          code: "#!/usr/bin/env node\n/**\n * Copyright\n */",
+          options: ["block", [
+            "*",
+            " * Copyright",
+            " "
+          ]]
         }
     ],
     invalid: [


### PR DESCRIPTION
Eslint 4 new returns [Shebangs](https://en.wikipedia.org/wiki/Shebang_(Unix)) along with other comments when requested where as it excluded them previously. This results in false positives in executable node.js files. See: https://eslint.org/docs/user-guide/migrating-to-4.0.0#shebangs

This change filters out Shebang lines from the comments from eslint so running the rule with eslint 4 should be consistent to running with previous versions of eslint.