### PR TITLE
Remove hardcoded linebreaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Often you will want to have a copyright notice at the top of every file. This ES
 
 ## Usage
 
-This rule takes 1 or 2 arguments.
+This rule takes 1 or 2 arguments with an optional settings object.
 
 ### 1 argument
 
@@ -35,7 +35,7 @@ Due to limitations in eslint plugins, the file is read relative to the working d
 
 ### 2 arguments
 
-In the 2 argument form the first must be either `"block"` or `"line"` to indiciate what style of comment should be used. The second is either a string (including newlines) of the comment, or an array of each line of the comment.
+In the 2 argument form the first must be either `"block"` or `"line"` to indicate what style of comment should be used. The second is either a string (including newlines) of the comment, or an array of each line of the comment.
 
 ```json
 {
@@ -60,6 +60,16 @@ Instead of a string to be checked for exact matching you can also supply a regul
     }
 }
 ```
+
+### Line Endings
+
+The rule works with both unix and windows line endings. For ESLint `--fix`, the rule will use the line ending format of the current operating system (via the node `os` package). This setting can be overwritten as follows:
+```json
+"rules": {
+    "header/header": [2, "block", ["Copyright 2018", "My Company"], {"lineEndings": "windows"}]
+}
+```
+Possible values are `unix` for `\n` and `windows` for `\r\n` line endings.
 
 ## Examples
 

--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var eol = require("os").EOL;
-
 // This is a really simple and dumb parser, that looks just for a
 // single kind of comment. It won't detect multiple block comments.
 
@@ -11,7 +9,7 @@ module.exports = function commentParser(text) {
     if (text.substr(0, 2) === "//") {
         return [
             "line",
-            text.split(eol).map(function(line) {
+            text.split(/\r?\n/).map(function(line) {
                 return line.substr(2);
             })
         ];

--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var eol = require("os").EOL;
+
 // This is a really simple and dumb parser, that looks just for a
 // single kind of comment. It won't detect multiple block comments.
 
@@ -9,8 +11,7 @@ module.exports = function commentParser(text) {
     if (text.substr(0, 2) === "//") {
         return [
             "line",
-            // TODO \r as well
-            text.split("\n").map(function(line) {
+            text.split(eol).map(function(line) {
                 return line.substr(2);
             })
         ];

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -2,7 +2,7 @@
 
 var fs = require("fs");
 var commentParser = require("../comment-parser");
-var eol = require("os").EOL;
+var os = require("os");
 
 function isPattern(object) {
     return typeof object === "object" && object.hasOwnProperty("pattern");
@@ -28,7 +28,7 @@ function getLeadingComments(context, node) {
         context.getComments(node).leading;
 }
 
-function genCommentBody(commentType, textArray) {
+function genCommentBody(commentType, textArray, eol) {
     if (commentType === "block") {
         return "/*" + textArray[0] + "*/" + eol;
     } else {
@@ -36,38 +36,58 @@ function genCommentBody(commentType, textArray) {
     }
 }
 
-function genCommentsRange(context, comments) {
+function genCommentsRange(context, comments, eol) {
     var start = comments[0].range[0];
     var end = comments.slice(-1)[0].range[1];
     if (context.getSourceCode().text[end] === eol) {
-        end++;
+        end += eol.length;
     }
     return [start, end];
 }
 
-function genPrependFixer(commentType, node, headerLines) {
+function genPrependFixer(commentType, node, headerLines, eol) {
     return function(fixer) {
         return fixer.insertTextBefore(
             node,
-            genCommentBody(commentType, headerLines)
+            genCommentBody(commentType, headerLines, eol)
         );
     };
 }
 
-function genReplaceFixer(commentType, context, leadingComments, headerLines) {
+function genReplaceFixer(commentType, context, leadingComments, headerLines, eol) {
     return function(fixer) {
         return fixer.replaceTextRange(
-            genCommentsRange(context, leadingComments),
-            genCommentBody(commentType, headerLines)
+            genCommentsRange(context, leadingComments, eol),
+            genCommentBody(commentType, headerLines, eol)
         );
     };
+}
+
+function findSettings(options) {
+    var lastOption = options.slice(-1)[0];
+    if (typeof lastOption === "object" && !Array.isArray(lastOption) && lastOption !== null && !lastOption.hasOwnProperty("pattern")) {
+        return lastOption;
+    }
+}
+
+function getEOL(options) {
+    var settings = findSettings(options);
+    if (settings && settings.lineEndings === "unix") {
+        return "\n";
+    }
+    if (settings && settings.lineEndings === "windows") {
+        return "\r\n";
+    }
+    return os.EOL;
 }
 
 module.exports = function(context) {
     var options = context.options;
 
+    var eol = getEOL(options);
+
     // If just one option then read comment from file
-    if (options.length === 1) {
+    if (options.length === 1 || (options.length === 2 && findSettings(options))) {
         var text = fs.readFileSync(context.options[0], "utf8");
         options = commentParser(text);
     }
@@ -94,8 +114,7 @@ module.exports = function(context) {
             headerLines = [new RegExp(options[1].pattern)];
         } else {
             canFix = true;
-            // TODO split on \r as well
-            headerLines = options[1].split(eol);
+            headerLines = options[1].split(/\r?\n/);
         }
     } else {
         if (Array.isArray(options[1])) {
@@ -117,7 +136,7 @@ module.exports = function(context) {
                 context.report({
                     loc: node.loc,
                     message: "missing header",
-                    fix: canFix ? genPrependFixer(commentType, node, header ? [header] : headerLines) : null
+                    fix: canFix ? genPrependFixer(commentType, node, header ? [header] : headerLines, eol) : null
                 });
             } else if (leadingComments[0].type.toLowerCase() !== commentType) {
                 context.report({
@@ -126,7 +145,7 @@ module.exports = function(context) {
                     data: {
                         commentType: commentType
                     },
-                    fix: canFix ? genReplaceFixer(commentType, context, leadingComments, header ? [header] : headerLines) : null
+                    fix: canFix ? genReplaceFixer(commentType, context, leadingComments, header ? [header] : headerLines, eol) : null
                 });
             } else {
                 if (commentType === "line") {
@@ -134,7 +153,7 @@ module.exports = function(context) {
                         context.report({
                             loc: node.loc,
                             message: "incorrect header",
-                            fix: canFix ? genReplaceFixer(commentType, context, leadingComments, headerLines) : null
+                            fix: canFix ? genReplaceFixer(commentType, context, leadingComments, headerLines, eol) : null
                         });
                         return;
                     }
@@ -143,7 +162,7 @@ module.exports = function(context) {
                             context.report({
                                 loc: node.loc,
                                 message: "incorrect header",
-                                fix: canFix ? genReplaceFixer(commentType, context, leadingComments, headerLines) : null
+                                fix: canFix ? genReplaceFixer(commentType, context, leadingComments, headerLines, eol) : null
                             });
                             return;
                         }
@@ -153,7 +172,7 @@ module.exports = function(context) {
                         context.report({
                             loc: node.loc,
                             message: "incorrect header",
-                            fix: canFix ? genReplaceFixer(commentType, context, leadingComments, [header]) : null
+                            fix: canFix ? genReplaceFixer(commentType, context, leadingComments, [header], eol) : null
                         });
                     }
                 }

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -2,6 +2,7 @@
 
 var fs = require("fs");
 var commentParser = require("../comment-parser");
+var eol = require("os").EOL;
 
 function isPattern(object) {
     return typeof object === "object" && object.hasOwnProperty("pattern");
@@ -29,16 +30,16 @@ function getLeadingComments(context, node) {
 
 function genCommentBody(commentType, textArray) {
     if (commentType === "block") {
-        return "/*" + textArray[0] + "*/\n";
+        return "/*" + textArray[0] + "*/" + eol;
     } else {
-        return "//" + textArray.join("\n//") + "\n";
+        return "//" + textArray.join(eol + "//") + eol;
     }
 }
 
 function genCommentsRange(context, comments) {
     var start = comments[0].range[0];
     var end = comments.slice(-1)[0].range[1];
-    if (context.getSourceCode().text[end] === "\n") {
+    if (context.getSourceCode().text[end] === eol) {
         end++;
     }
     return [start, end];
@@ -94,12 +95,12 @@ module.exports = function(context) {
         } else {
             canFix = true;
             // TODO split on \r as well
-            headerLines = options[1].split("\n");
+            headerLines = options[1].split(eol);
         }
     } else {
         if (Array.isArray(options[1])) {
             canFix = true;
-            header = options[1].join("\n");
+            header = options[1].join(eol);
         } else if (isPattern(options[1])) {
             header = new RegExp(options[1].pattern);
         } else {

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -64,7 +64,7 @@ function genReplaceFixer(commentType, context, leadingComments, headerLines, eol
 }
 
 function findSettings(options) {
-    var lastOption = options.slice(-1)[0];
+    var lastOption = options.length > 0 ? options[options.length - 1] : null;
     if (typeof lastOption === "object" && !Array.isArray(lastOption) && lastOption !== null && !lastOption.hasOwnProperty("pattern")) {
         return lastOption;
     }

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -70,6 +70,22 @@ ruleTester.run("header", rule, {
                 " * Copyright",
                 " "
             ]]
+        },
+        {
+            code: "// Copyright 2015\r\n// My Company\r\nconsole.log(1)",
+            options: ["tests/support/line.js"]
+        },
+        {
+            code: "//Copyright 2018\r\n//My Company\r\n/* DOCS */",
+            options: ["line", ["Copyright 2018", "My Company"]]
+        },
+        {
+            code: "/*Copyright 2018\r\nMy Company*/\r\nconsole.log(1)",
+            options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "windows"}]
+        },
+        {
+            code: "/*Copyright 2018\nMy Company*/\nconsole.log(1)",
+            options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "unix"}]
         }
     ],
     invalid: [
@@ -138,6 +154,13 @@ ruleTester.run("header", rule, {
         {
             code: "/* Copyright 2017-01-02\n Author: abc@example.com */",
             options: ["block", {pattern: "^ Copyright \\d+\\n Author: \\w+@\\w+\\.\\w+ $"}],
+            errors: [
+                {message: "incorrect header"}
+            ]
+        },
+        {
+            code: "/*Copyright 2018\r\nMy Company*/\r\nconsole.log(1)",
+            options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "unix"}],
             errors: [
                 {message: "incorrect header"}
             ]


### PR DESCRIPTION
Hardcoded line breaks like `\n` don't work cross platform (e.g. Windows). Instead `os.EOL` should be used.