### PR TITLE
Don't fix missing header if no template provided

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -169,7 +169,7 @@ module.exports = {
                     context.report({
                         loc: node.loc,
                         message: "missing header",
-                        fix: genPrependFixer(commentType, node, fixLines, eol, numNewlines)
+                        fix: canFix ? genPrependFixer(commentType, node, fixLines, eol, numNewlines) : null
                     });
                 } else {
                     var leadingComments = getLeadingComments(context, node);

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -199,6 +199,22 @@ ruleTester.run("header", rule, {
             ]
         },
         {
+            code: "console.log(1);",
+            options: ["line", {pattern: "^ Copyright \\d+$"}],
+            errors: [
+                {message: "missing header"}
+            ],
+            output: "console.log(1);"
+        },
+        {
+            code: "console.log(1);",
+            options: ["line", {pattern: "^ Copyright \\d+$", template: " Copyright 2018"}],
+            errors: [
+                {message: "missing header"}
+            ],
+            output: "// Copyright 2018\nconsole.log(1);"
+        },
+        {
             code: "// Copyright 2017 trailing",
             options: ["line", {pattern: "^ Copyright \\d+$", template: " Copyright 2018"}],
             errors: [


### PR DESCRIPTION
Currently it inserts a dumb comment like:

```
//[object Object]
```

if no template is provided. I added a couple of test cases to validate correct handling.