### PR TITLE
Preserving new lines at the end of the template file (fixes #37)

### DIFF
--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -6,10 +6,10 @@
 module.exports = function commentParser(text) {
     // @see https://stackoverflow.com/a/20060315
     var trailingNewLinesMatches = text.match(/\n(?=\s*$)/g);
-    var trailingNewLinesCount = 0;
+    var trailingNewLinesCount = 1;
 
     if (trailingNewLinesMatches) {
-        trailingNewLinesCount = trailingNewLinesMatches.length;
+        trailingNewLinesCount += trailingNewLinesMatches.length;
     }
 
     text = text.trim();

--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -4,6 +4,14 @@
 // single kind of comment. It won't detect multiple block comments.
 
 module.exports = function commentParser(text) {
+    // @see https://stackoverflow.com/a/20060315
+    var trailingNewLinesMatches = text.match(/\n(?=\s*$)/g);
+    var trailingNewLinesCount = 0;
+
+    if (trailingNewLinesMatches) {
+        trailingNewLinesCount = trailingNewLinesMatches.length;
+    }
+
     text = text.trim();
 
     if (text.substr(0, 2) === "//") {
@@ -11,13 +19,14 @@ module.exports = function commentParser(text) {
             "line",
             text.split(/\r?\n/).map(function(line) {
                 return line.substr(2);
-            })
+            }),
+            trailingNewLinesCount
         ];
     } else if (
         text.substr(0, 2) === "/*" &&
         text.substr(-2) === "*/"
     ) {
-        return ["block", text.substring(2, text.length - 2)];
+        return ["block", text.substring(2, text.length - 2), trailingNewLinesCount];
     } else {
         throw new Error("Could not parse comment file: the file must contain either just line comments (//) or a single block comment (/* ... */)");
     }

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -125,14 +125,15 @@ module.exports = {
     },
     create: function(context) {
         var options = context.options;
-        var numNewlines = options.length > 2 ? options[2] : 1;
-        var eol = getEOL(options);
 
         // If just one option then read comment from file
         if (options.length === 1 || (options.length === 2 && findSettings(options))) {
             var text = fs.readFileSync(context.options[0], "utf8");
             options = commentParser(text);
         }
+
+        var numNewlines = options.length > 2 ? options[2] : 1;
+        var eol = getEOL(options);
 
         var commentType = options[0].toLowerCase();
         var headerLines, fixLines = [];

--- a/tests/lib/comment-parser-test.js
+++ b/tests/lib/comment-parser-test.js
@@ -7,7 +7,12 @@ var commentParser = require("../../lib/comment-parser");
 describe("comment parser", function() {
     it("parses block comments", function() {
         var result = commentParser("/* pass1\n pass2 */  ");
-        assert.deepEqual(result, ["block", " pass1\n pass2 "]);
+        assert.deepEqual(result, ["block", " pass1\n pass2 ", 0]);
+    });
+
+    it("parses block comments with Windows EOLs", function() {
+        var result = commentParser("/* pass1\r\n pass2 */\r\n\r\n  ");
+        assert.deepEqual(result, ["block", " pass1\r\n pass2 ", 2]);
     });
 
     it("throws an error when a block comment isn't ended", function() {
@@ -18,6 +23,6 @@ describe("comment parser", function() {
 
     it("parses line comments", function() {
         var result = commentParser("// pass1\n// pass2\n  ");
-        assert.deepEqual(result, ["line", [" pass1", " pass2"]]);
+        assert.deepEqual(result, ["line", [" pass1", " pass2"], 1]);
     });
 });


### PR DESCRIPTION
This PR fixes #37.

### Implementation details:
- the comment parser now returns a third array value with the number of new lines at the end of the given comment
- the initialization function runs the parser before setting the new lines count and EOL format in order to base its decisions on the template file content (if available)
- tests have been updated to support the new parser feature and check that both UNIX and Windows EOLs work properly

I hope that this can be useful, please feel free to ask for changes or any further information.

Thank you for your time.