### PR TITLE
Option to allow eslint-disable comment before the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ The rule works with both unix and windows line endings. For ESLint `--fix`, the 
 ```
 Possible values are `unix` for `\n` and `windows` for `\r\n` line endings.
 
+### ESlint disable comments
+
+Sometimes you want to add a eslint-disable for the whole file before the header. This can be done by adding a settings as follows:
+
+```json
+"rules": {
+    "header/header": [2, "block", ["Copyright 2018", "My Company"], {"allowDisableFirst": true}]
+}
+```
+
 ## Examples
 
 The following examples are all valid.

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -26,11 +26,25 @@ function excludeShebangs(comments) {
 // are ONLY separated by a single newline. Note that this does not actually
 // check if they are at the start of the file since that is already checked by
 // hasHeader().
-function getLeadingComments(context, node) {
+function getLeadingComments(context, node, allowDisableFirst) {
     var all = excludeShebangs(context.getSourceCode().getAllComments(node.body.length ? node.body[0] : node));
-    if (all[0].type.toLowerCase() === "block") {
+
+    if(allowDisableFirst) {
+      for (var i = 1; i < all.length; ++i) {
+        if (all[i].type.toLowerCase() === "block") {
+          if(all[i].value.trim().indexOf('eslint-disable') === -1) {
+            return [all[i]];
+          }
+        }
+      }
+    } else {
+      if (all[0].type.toLowerCase() === "block") {
         return [all[0]];
+      }
     }
+
+
+
     for (var i = 1; i < all.length; ++i) {
         var txt = context.getSourceCode().getText().slice(all[i - 1].range[1], all[i].range[0]);
         if (!txt.match(/^(\r\n|\r|\n)$/)) {
@@ -85,6 +99,15 @@ function findSettings(options) {
     return null;
 }
 
+function getAllowDisableFirst(options) {
+    var settings = findSettings(options);
+    if (settings && settings.allowDisableFirst !== undefined) {
+        return !!settings.allowDisableFirst;
+    }
+
+    return false;
+}
+
 function getEOL(options) {
     var settings = findSettings(options);
     if (settings && settings.lineEndings === "unix") {
@@ -127,6 +150,7 @@ module.exports = {
         var options = context.options;
         var numNewlines = options.length > 2 ? options[2] : 1;
         var eol = getEOL(options);
+        var allowDisableFirst = getAllowDisableFirst(options);
 
         // If just one option then read comment from file
         if (options.length === 1 || (options.length === 2 && findSettings(options))) {
@@ -172,7 +196,7 @@ module.exports = {
                         fix: genPrependFixer(commentType, node, fixLines, eol, numNewlines)
                     });
                 } else {
-                    var leadingComments = getLeadingComments(context, node);
+                    var leadingComments = getLeadingComments(context, node, allowDisableFirst);
 
                     if (!leadingComments.length) {
                         context.report({

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -29,29 +29,27 @@ function excludeShebangs(comments) {
 function getLeadingComments(context, node, allowDisableFirst) {
     var all = excludeShebangs(context.getSourceCode().getAllComments(node.body.length ? node.body[0] : node));
 
-    if(allowDisableFirst) {
-      for (var i = 1; i < all.length; ++i) {
-        if (all[i].type.toLowerCase() === "block") {
-          if(all[i].value.trim().indexOf('eslint-disable') === -1) {
-            return [all[i]];
-          }
+    if (allowDisableFirst) {
+        for (var i = 1; i < all.length; ++i) {
+            if (all[i].type.toLowerCase() === "block") {
+                if (all[i].value.trim().indexOf("eslint-disable") === -1) {
+                    return [all[i]];
+                }
+            }
         }
-      }
     } else {
-      if (all[0].type.toLowerCase() === "block") {
-        return [all[0]];
-      }
+        if (all[0].type.toLowerCase() === "block") {
+            return [all[0]];
+        }
     }
 
-
-
-    for (var i = 1; i < all.length; ++i) {
-        var txt = context.getSourceCode().getText().slice(all[i - 1].range[1], all[i].range[0]);
+    for (var j = 1; j < all.length; ++j) {
+        var txt = context.getSourceCode().getText().slice(all[j - 1].range[1], all[j].range[0]);
         if (!txt.match(/^(\r\n|\r|\n)$/)) {
             break;
         }
     }
-    return all.slice(0, i);
+    return all.slice(0, j);
 }
 
 function genCommentBody(commentType, textArray, eol, numNewlines) {
@@ -101,8 +99,8 @@ function findSettings(options) {
 
 function getAllowDisableFirst(options) {
     var settings = findSettings(options);
-    if (settings && settings.allowDisableFirst !== undefined) {
-        return !!settings.allowDisableFirst;
+    if (settings && settings.allowDisableFirst === true) {
+        return true;
     }
 
     return false;

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -30,7 +30,7 @@ function getLeadingComments(context, node, allowDisableFirst) {
     var all = excludeShebangs(context.getSourceCode().getAllComments(node.body.length ? node.body[0] : node));
 
     if (allowDisableFirst) {
-        for (var i = 1; i < all.length; ++i) {
+        for (var i = 0; i < all.length; ++i) {
             if (all[i].type.toLowerCase() === "block") {
                 if (all[i].value.trim().indexOf("eslint-disable") === -1) {
                     return [all[i]];

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -123,7 +123,11 @@ ruleTester.run("header", rule, {
                 " * Copyright",
                 " "
             ], 0]
-        }
+        },
+        {
+            code: "/* eslint-disable max-lines */\n/**\n * Copyright 2020\n * My Company\n **/\n\n/*Log number one*/\nconsole.log(1);",
+            options: ["block", "*\n * Copyright 2020\n * My Company\n *", 2, {"allowDisableFirst": true}],
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
By default, in VSCode, the option for disabling a eslint rule for the whole file place the comment on top of the file, before the header. That cause the header rule to be invalid, and the eslint comment must be moved manually

This PR add an option `allowDisableFirst`. When enabled, the eslint-disable comment are ignored from the getLeadingComments function