### PR TITLE
Add rules schema for ESLint 9 compatibility

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -121,7 +121,97 @@ function matchesLineEndings(src, num) {
 module.exports = {
     meta: {
         type: "layout",
-        fixable: "whitespace"
+        fixable: "whitespace",
+        schema: {
+            $ref: "#/definitions/options",
+            definitions: {
+                commentType: {
+                    type: "string",
+                    enum: ["block", "line"]
+                },
+                line: {
+                    anyOf: [
+                        {
+                            type: "string"
+                        },
+                        {
+                            type: "object",
+                            properties: {
+                                pattern: {
+                                    type: "string"
+                                },
+                                template: {
+                                    type: "string"
+                                }
+                            },
+                            required: ["pattern"],
+                            additionalProperties: false
+                        }
+                    ]
+                },
+                headerLines: {
+                    anyOf: [
+                        {
+                            $ref: "#/definitions/line"
+                        },
+                        {
+                            type: "array",
+                            items: {
+                                $ref: "#/definitions/line"
+                            }
+                        }
+                    ]
+                },
+                numNewlines: {
+                    type: "integer",
+                    minimum: 0
+                },
+                settings: {
+                    type: "object",
+                    properties: {
+                        lineEndings: {
+                            type: "string",
+                            enum: ["unix", "windows"]
+                        }
+                    },
+                    additionalProperties: false
+                },
+                options: {
+                    anyOf: [
+                        {
+                            type: "array",
+                            minItems: 1,
+                            maxItems: 2,
+                            items: [
+                                { type: "string" },
+                                { $ref: "#/definitions/settings" }
+                            ]
+                        },
+                        {
+                            type: "array",
+                            minItems: 2,
+                            maxItems: 3,
+                            items: [
+                                { $ref: "#/definitions/commentType" },
+                                { $ref: "#/definitions/headerLines" },
+                                { $ref: "#/definitions/settings" }
+                            ]
+                        },
+                        {
+                            type: "array",
+                            minItems: 3,
+                            maxItems: 4,
+                            items: [
+                                { $ref: "#/definitions/commentType" },
+                                { $ref: "#/definitions/headerLines" },
+                                { $ref: "#/definitions/numNewlines" },
+                                { $ref: "#/definitions/settings" }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
     },
     create: function(context) {
         var options = context.options;


### PR DESCRIPTION
ESLint 9 now requires that plugins provide a schema if they accept options; see https://eslint.org/blog/2024/04/eslint-v9.0.0-released/#changes-to-how-you-write-rules.